### PR TITLE
Improvements for pick-and-drop

### DIFF
--- a/src/vrep_plugin.cpp
+++ b/src/vrep_plugin.cpp
@@ -439,7 +439,8 @@ SimulationData::SimulationData(mc_control::MCGlobalController & controller) : gc
       mc_rtc::log::error(
           "mc_rtc is trying to control {} in CoppeliaSim but it cannot find it in the scene, either:\n1. The object "
           "does not have a model base in CoppeliaSim\n2. The object's name in mc_rtc does not match its name in "
-          "CoppeliaSim\n3. The joints' names do not match between mc_rtc and CoppeliaSim");
+          "CoppeliaSim\n3. The joints' names do not match between mc_rtc and CoppeliaSim",
+          name);
       return;
     }
     std::vector<VREPRobot::VREPJoint> refJointToHandle(robot.refJointOrder().size());

--- a/src/vrep_plugin.cpp
+++ b/src/vrep_plugin.cpp
@@ -844,6 +844,10 @@ static void setup_datastore()
         return false;
       }
     });
+    ds.make_call("CoppeliaSim::GetObjectPose", [](const std::string & object) -> sva::PTransformd {
+      auto obj_id = simGetObjectHandle(object.c_str());
+      return utils::getObjectPose(obj_id);
+    });
   };
   add_datastore_entries(ctl);
 }

--- a/src/vrep_plugin.cpp
+++ b/src/vrep_plugin.cpp
@@ -884,6 +884,37 @@ static void setup_datastore()
         return false;
       }
     });
+    /**
+     * @brief Changes the respondable state of an object
+     *
+     * @param object Object name in CoppeliaSim
+     * @param respondable When true the object becomes respondable; false means non-respondable
+     */
+    ds.make_call("CoppeliaSim::SetObjectRespondableProperty", [](const std::string & object, bool respondable) -> bool {
+      auto obj_id = simGetObjectHandle(object.c_str());
+      if(obj_id == -1)
+      {
+        mc_rtc::log::error("Object \"{}\" not found", obj_id);
+        return false;
+      }
+      if(simSetObjectInt32Parameter(obj_id, sim_shapeintparam_respondable, respondable) != -1)
+      {
+        if(respondable)
+        {
+          mc_rtc::log::info("Object \"{}\" is now respondable", object);
+        }
+        else
+        {
+          mc_rtc::log::info("Object \"{}\" is now non-respondable", object);
+        }
+        return true;
+      }
+      else
+      {
+        mc_rtc::log::error("Failed to change respondable property for object \"{}\"", object);
+        return false;
+      }
+    });
     ds.make_call("CoppeliaSim::GetObjectPose", [](const std::string & object) -> sva::PTransformd {
       auto obj_id = simGetObjectHandle(object.c_str());
       if(obj_id == -1)


### PR DESCRIPTION
This PR contains improvements for the pick-and-drop demo:
- Add datastore callbacks:
  - changing the parent of an object
  - switching an object between dynamic/static state
  -  getting an object's pose

\+ minor fixes